### PR TITLE
Support locales that display temps in Fahrenheit.

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,8 +18,10 @@
       "snmp_query_interval_in_sec": 3,
       "ifttt_api_key": "xxxxxxxx",
       "ifttt_event": "homebridge",
-      "ifttt_threshold_mbps": 100, 
-      "ifttt_maximum_notification_interval_in_sec": 300 
+      "ifttt_threshold_mbps": 100,
+      "ifttt_maximum_notification_interval_in_sec": 300,
+      "locale_uses_fahrenheit": false,
+      "verbose": false,
     },
     {
       "accessory": "BandwidthMeter",
@@ -32,8 +34,10 @@
       "snmp_query_interval_in_sec": 3,
       "ifttt_api_key": "xxxxxxxx",
       "ifttt_event": "homebridge",
-      "ifttt_threshold_mbps": 9, 
-      "ifttt_maximum_notification_interval_in_sec": 300 
+      "ifttt_threshold_mbps": 9,
+      "ifttt_maximum_notification_interval_in_sec": 300,
+      "locale_uses_fahrenheit": false,
+      "verbose": false,
     }
   ]
 }


### PR DESCRIPTION
Because HomeKit displays temp sensors using locale-dependent degrees (Celsius/Fahrenheit), providing the Mbps value directly won't always yield the expected results. Added a flag to enable conversion if in a Fahrenheit locale, also uncommented some useful logging statements and wrapped them in a (defaults: false) verbose config to help folks troubleshoot.